### PR TITLE
Fixed file not found bug by checking in IsFolder

### DIFF
--- a/lib/installfont.js
+++ b/lib/installfont.js
@@ -29,6 +29,12 @@ if(platform.toLowerCase().indexOf('linux') != -1) {
 
 /*======== Module Utilities ========*/
 var isFolder = function (fontPath) {
+
+  fs.exists(fontPath, function (exists) {
+  if (!exists)
+      return invokeCallBack(new Error("Specified directory does not exist: " + fontPath));
+  });
+  
   var stats = fs.statSync(fontPath);
   return stats.isDirectory();
 };

--- a/lib/installfont.js
+++ b/lib/installfont.js
@@ -29,14 +29,16 @@ if(platform.toLowerCase().indexOf('linux') != -1) {
 
 /*======== Module Utilities ========*/
 var isFolder = function (fontPath) {
-
+  // Before we check to see if it's a folder, let's make sure that bad boy exists
   fs.exists(fontPath, function (exists) {
-  if (!exists)
+    if (!exists) {
       return invokeCallBack(new Error("Specified directory does not exist: " + fontPath));
-  });
-  
-  var stats = fs.statSync(fontPath);
-  return stats.isDirectory();
+    }
+    else {
+      var stats = fs.statSync(fontPath);
+      return stats.isDirectory();
+    }
+  });  
 };
 
 

--- a/lib/installfont.js
+++ b/lib/installfont.js
@@ -32,7 +32,7 @@ var isFolder = function (fontPath) {
 
   fs.exists(fontPath, function (exists) {
   if (!exists)
-      return invokeCallBack(new Error("Specified directory does not exist: " + fontPath));
+      return invokeCallBack(new Error("Specified path does not exist: " + fontPath));
   });
   
   var stats = fs.statSync(fontPath);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.3",
   "description": "Super easy nodejs system font installation",
   "author": "Mat Silva <askmatsilva@gmail.com>",
+  "contributors": [{
+    "name": "Zach Sadler",
+    "email" "zaxcoding@gmail.com"
+    }],
   "scripts": {
     "test": "mocha spec"
   },


### PR DESCRIPTION
The error checking for if the path existed was done after determining if the path was a file or a folder. We used fs.fstatsync to determine if the path was a file or folder, but calling that on an invalid filepath throws the error referenced in the issue.
Moving the 'exists' check to the isFolder method allows us to catch this error beforehand.
